### PR TITLE
Pointing resources to the right place

### DIFF
--- a/confs/gearman_config.xml
+++ b/confs/gearman_config.xml
@@ -1,5 +1,5 @@
 <hudson.plugins.gearman.GearmanPluginConfig>
 <enablePlugin>true</enablePlugin>
-<host>127.0.0.1</host>
+<host>ci.localdomain</host>
 <port>4730</port>
 </hudson.plugins.gearman.GearmanPluginConfig>

--- a/confs/jenkins_jobs.ini
+++ b/confs/jenkins_jobs.ini
@@ -1,4 +1,4 @@
 [jenkins]
 user=jenkins
 password=password
-url=http://localhost:8081/jenkins
+url=http://ci.localdomain:8081/jenkins

--- a/confs/zuul.conf
+++ b/confs/zuul.conf
@@ -24,5 +24,5 @@ zuul_url=http://ci.localdomain/p
 log_config=/etc/zuul/merger-logging.conf
 
 [smtp]
-server=localhost
+server=ci.localdomain
 port=25

--- a/confs/zuul_site.conf
+++ b/confs/zuul_site.conf
@@ -4,7 +4,7 @@
   LogLevel warn
 
   RewriteEngine on
-  RewriteRule ^/status.json$ http://127.0.0.1:8001/status.json [P]
+  RewriteRule ^/status.json$ http://ci.localdomain:8001/status.json [P]
 
   SetEnv GIT_PROJECT_ROOT /var/lib/zuul/git/
   SetEnv GIT_HTTP_EXPORT_ALL


### PR DESCRIPTION
Apparently you should always use ci.localdomain, instead of 127.0.0.1
or even localhost. Otherwise gearman is not able to find Jenkins
instance, for example.
